### PR TITLE
Reword flag messages

### DIFF
--- a/api/channels.js
+++ b/api/channels.js
@@ -237,7 +237,7 @@ router.post("/:channelid/invites", channelMiddleware, channelPermissionsMiddlewa
         if (config.instance_flags.includes("NO_INVITE_CREATION")) {
             return res.status(400).json({
                 code: 400,
-                message: "Creating invites is not allowed. Please try again later."
+                message: "Creating invites is not allowed."
             })
         }
 

--- a/helpers/globalutils.js
+++ b/helpers/globalutils.js
@@ -89,16 +89,16 @@ const globalUtils = {
 
         switch(flag) {
             case "NO_REGISTRATION":
-                ret = "Account registration is currently disabled on this instance. Please try again later."
+                ret = "Account registration is currently disabled on this instance."
                 break;
             case "NO_GUILD_CREATION":
-                ret = "Creating guilds is not allowed at this time. Please try again later."
+                ret = "Creating guilds is currently not allowed on this instance."
                 break;
             case "NO_INVITE_USE":
-                ret = "You are not allowed to accept this invite. Please try again later."
+                ret = "You are not allowed to accept this invite."
                 break;
             case "NO_INVITE_CREATION":
-                ret = "Creating invites is not allowed. Please try again later."
+                ret = "Creating invites is not allowed on this instance."
                 break;
         }
 


### PR DESCRIPTION
some instances won't ever disable these flags, depending on what the owner wants the instance for. some instances may be invite-only, for example. temporary variants to these flags could be added (eg `NO_REGISTRATION_TEMP`) which include the "Please try again later" message.